### PR TITLE
Bugfix/13 type check

### DIFF
--- a/mappymatch/constructs/trace.py
+++ b/mappymatch/constructs/trace.py
@@ -18,6 +18,8 @@ from mappymatch.utils.geohash import encode
 class Trace:
     _frame: GeoDataFrame
 
+    coords_list: List[Coordinate]
+
     def __init__(self, frame: GeoDataFrame):
         self._frame = frame
 
@@ -42,11 +44,11 @@ class Trace:
 
     @cached_property
     def coords(self) -> List[Coordinate]:
-        coords = [
+        coords_list = [
             Coordinate(i, g, self.crs)
             for i, g in zip(self._frame.index, self._frame.geometry)
         ]
-        return coords
+        return coords_list
 
     def geohashes(self, precision=12) -> Set[str]:
         """

--- a/mappymatch/matchers/lcss/constructs.py
+++ b/mappymatch/matchers/lcss/constructs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import random
 import time
-from typing import NamedTuple, List
+from typing import NamedTuple, List, Union
 
 import numpy as np
 
@@ -154,14 +154,13 @@ class TrajectorySegment(NamedTuple):
             start_end_dist = start.geom.distance(end.geom)
 
             if start_end_dist < distance_epsilon:
-                # CuttingPoint.trace_index will be used later as a slice index (which
-                # has to be an int) so explictly convert the numpy type to an int now
-                # rather than wait for the adhoc construction of the int on use
-                p1 = int(np.argmax(
+                p1 = np.argmax(
                     [coord_to_coord_dist(start, c) for c in self.trace.coords]
-                ))
-                p2 = int(np.argmax([coord_to_coord_dist(end, c) for c in self.trace.coords]))
-
+                )
+                p2 = np.argmax([coord_to_coord_dist(end, c) for c in self.trace.coords])
+                # To do - np.argmax returns array of indices where the highest value is found.
+                # if there is only one highest value an int is returned. CuttingPoint takes an int.
+                # if an array is returned by argmax, this throws an error
                 cp1 = CuttingPoint(p1)
                 cp2 = CuttingPoint(p2)
 
@@ -172,15 +171,15 @@ class TrajectorySegment(NamedTuple):
                 cp = CuttingPoint(mid)
                 cutting_points.append(cp)
         else:
-            # find furthest point (see note above for p1 and p2 about why the cast is here)
-            i = int(np.argmax([m.distance for m in self.matches if m.road]))
+            # find furthest point
+            i = np.argmax([m.distance for m in self.matches if m.road])
             cutting_points.append(CuttingPoint(i))
 
             # collect points that are close to the distance threshold
-            for j, m in enumerate(self.matches):
+            for i, m in enumerate(self.matches):
                 if m.road:
                     if abs(m.distance - distance_epsilon) < cutting_thresh:
-                        cutting_points.append(CuttingPoint(j))
+                        cutting_points.append(CuttingPoint(i))
 
         # add random points
         for _ in range(random_cuts):

--- a/mappymatch/matchers/lcss/constructs.py
+++ b/mappymatch/matchers/lcss/constructs.py
@@ -6,6 +6,7 @@ import time
 from typing import NamedTuple, List, Union
 
 import numpy as np
+from numpy import ndarray, signedinteger
 
 from mappymatch.constructs.match import Match
 from mappymatch.constructs.road import Road
@@ -17,7 +18,7 @@ log = logging.getLogger(__name__)
 
 
 class CuttingPoint(NamedTuple):
-    trace_index: int
+    trace_index: Union[signedinteger, int]
 
 
 class TrajectorySegment(NamedTuple):
@@ -158,9 +159,8 @@ class TrajectorySegment(NamedTuple):
                     [coord_to_coord_dist(start, c) for c in self.trace.coords]
                 )
                 p2 = np.argmax([coord_to_coord_dist(end, c) for c in self.trace.coords])
-                # To do - np.argmax returns array of indices where the highest value is found.
-                # if there is only one highest value an int is returned. CuttingPoint takes an int.
-                # if an array is returned by argmax, this throws an error
+                assert not isinstance(p1, ndarray)
+                assert not isinstance(p2, ndarray)
                 cp1 = CuttingPoint(p1)
                 cp2 = CuttingPoint(p2)
 
@@ -172,8 +172,8 @@ class TrajectorySegment(NamedTuple):
                 cutting_points.append(cp)
         else:
             # find furthest point
-            i = np.argmax([m.distance for m in self.matches if m.road])
-            cutting_points.append(CuttingPoint(i))
+            pre_i = np.argmax([m.distance for m in self.matches if m.road])
+            cutting_points.append(CuttingPoint(pre_i))
 
             # collect points that are close to the distance threshold
             for i, m in enumerate(self.matches):

--- a/mappymatch/utils/geo.py
+++ b/mappymatch/utils/geo.py
@@ -66,7 +66,7 @@ def road_to_coord_dist(road: Road, coord: Coordinate) -> float:
     return dist
 
 
-def coord_to_coord_dist(a: Coordinate, b: Coordinate):
+def coord_to_coord_dist(a: Coordinate, b: Coordinate) -> float:
     """
     helper function to compute the distance between to coordinates
 


### PR DESCRIPTION
While working on the issue (https://github.com/NREL/mappymatch/issues/51) of types, we hit on the solution of allowing CuttingPoint to accept a wider variety of types, in accordance with PyCon 2022 keynote speech. In the meantime, another commit had resolved the typing error by casting all values to int.

We decided to let the reviewer decide on the approach.

Also asserts that `argmax()` is not returning a multidimensional array, which is currently logically impossible given its input but could change in the future. This also satisifies `mypy`