### PR TITLE
Update docs to use new project name

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,7 @@ print(os.path.abspath('../..'))
 
 # -- Project information -----------------------------------------------------
 
-project = 'Yet Another Map Matcher'
+project = 'Mappymatch'
 copyright = '2022, National Renewable Energy Laboratory'
 author = 'National Renewable Energy Laboratory'
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,10 +1,10 @@
-.. Yet Another Map Matcher documentation master file, created by
+.. MapPyMatch documentation master file, created by
    sphinx-quickstart on Mon May  2 10:18:14 2022.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-YAMM Documentation
-==================
+MapPyMatch Documentation
+========================
 
 .. toctree::
    :maxdepth: 2
@@ -12,7 +12,7 @@ YAMM Documentation
 
    reference/index
 
-Yet Another Map Matcher (YAMM) is a pure-python package developed by the National Renewable Energy Laboratory that maintains a collection of map matching algorithms and wrappers. The package was designed for ease of use and portabilty across platforms.
+MapPyMatch is a pure-python package developed by the National Renewable Energy Laboratory that maintains a collection of map matching algorithms and wrappers. The package was designed for ease of use and portabilty across platforms.
 
 Installation
 ------------
@@ -27,11 +27,11 @@ From Source (recommended)
 
 First, clone the repository::
 
-   git clone https://github.com/NREL/yamm.git && cd yamm
+   git clone https://github.com/NREL/mappymatch.git && cd mappymatch
 
 Then, setup a python environment with Python (at least version 3.8)::
 
-   conda create -n yamm python=3.8
+   conda create -n mappymatch python=3.8
 
 Finally, use pip to install the package::
 
@@ -52,11 +52,11 @@ The ``LCSSMatcher`` implements the map matching algorithm described in `this <ht
 
 .. code-block:: python
 
-   from yamm import root
-   from yamm.matchers.lcss.lcss import LCSSMatcher
-   from yamm.utils.geo import geofence_from_trace
-   from yamm.maps.nx.readers.osm_readers import read_osm_nxmap
-   from yamm.constructs.trace import Trace
+   from mappymatch import root
+   from mappymatch.matchers.lcss.lcss import LCSSMatcher
+   from mappymatch.utils.geo import geofence_from_trace
+   from mappymatch.maps.nx.readers.osm_readers import read_osm_nxmap
+   from mappymatch.constructs.trace import Trace
 
    trace = Trace.from_csv(root() / "resources/traces/sample_trace_1.csv")
 

--- a/docs/source/reference/constructs.rst
+++ b/docs/source/reference/constructs.rst
@@ -4,17 +4,17 @@ Constructs
 
 Constructs are the fundamental datastructures shared between all matching implementations.
 
-.. automodule:: yamm.constructs.coordinate
+.. automodule:: mappymatch.constructs.coordinate
     :members:
 
-.. automodule:: yamm.constructs.geofence
+.. automodule:: mappymatch.constructs.geofence
     :members:
 
-.. automodule:: yamm.constructs.match
+.. automodule:: mappymatch.constructs.match
     :members:
 
-.. automodule:: yamm.constructs.road
+.. automodule:: mappymatch.constructs.road
     :members:
 
-.. automodule:: yamm.constructs.trace
+.. automodule:: mappymatch.constructs.trace
     :members:

--- a/docs/source/reference/maps.rst
+++ b/docs/source/reference/maps.rst
@@ -1,18 +1,18 @@
 Maps
 ====
 
-The type of map used to display data can be changed based on what works best for you application. Each map class must conform to the map interface defined in :class:`yamm.maps.map_interface`.
+The type of map used to display data can be changed based on what works best for you application. Each map class must conform to the map interface defined in :class:`mappymatch.maps.map_interface`.
 
 Available Maps
 --------------
 
-- :class:`yamm.maps.nx.nx_map.NxMap`
+- :class:`mappymatch.maps.nx.nx_map.NxMap`
 
-.. automodule:: yamm.maps.nx.nx_map
+.. automodule:: mappymatch.maps.nx.nx_map
     :members:
 
 Map Interface
 -------------
 
-.. automodule:: yamm.maps.map_interface
+.. automodule:: mappymatch.maps.map_interface
     :members:

--- a/docs/source/reference/matchers.rst
+++ b/docs/source/reference/matchers.rst
@@ -1,22 +1,22 @@
 Matchers
 ========
 
-There are several matchers that can be used to determine the road that a coordinate is *matched* to. Matchers may have tradeoffs between speed and accuracy. Each map class must conform to the matcher interface defined in :class:`yamm.matchers.matcher_interface.MatcherInterface`.
+There are several matchers that can be used to determine the road that a coordinate is *matched* to. Matchers may have tradeoffs between speed and accuracy. Each map class must conform to the matcher interface defined in :class:`mappymatch.matchers.matcher_interface.MatcherInterface`.
 
 Available Matchers
 ------------------
 
-- :class:`yamm.matchers.line_snap.LineSnapMatcher`
-- :class:`yamm.matchers.osrm.OsrmMatcher`
+- :class:`mappymatch.matchers.line_snap.LineSnapMatcher`
+- :class:`mappymatch.matchers.osrm.OsrmMatcher`
 
-.. autoclass:: yamm.matchers.line_snap.LineSnapMatcher
+.. autoclass:: mappymatch.matchers.line_snap.LineSnapMatcher
     :members:
 
-.. autoclass:: yamm.matchers.osrm.OsrmMatcher
+.. autoclass:: mappymatch.matchers.osrm.OsrmMatcher
     :members:
 
 Matcher Interface
 -----------------
 
-.. automodule:: yamm.matchers.matcher_interface
+.. automodule:: mappymatch.matchers.matcher_interface
     :members:

--- a/docs/source/reference/utils.rst
+++ b/docs/source/reference/utils.rst
@@ -6,29 +6,29 @@ Helper functions and classes.
 Geo Utilities
 -------------
 
-.. automodule:: yamm.utils.geo
+.. automodule:: mappymatch.utils.geo
     :members:
 
 Geo Hash Utilities
 ------------------
 
-.. automodule:: yamm.utils.geohash
+.. automodule:: mappymatch.utils.geohash
     :members:
 
 Plot Utilities
 ------------------
 
-.. automodule:: yamm.utils.plot
+.. automodule:: mappymatch.utils.plot
     :members:
 
 Process Trace Utilities
 -----------------------
 
-.. automodule:: yamm.utils.process_trace
+.. automodule:: mappymatch.utils.process_trace
     :members:
 
 URL Utilities
 -------------
 
-.. automodule:: yamm.utils.url
+.. automodule:: mappymatch.utils.url
     :members:


### PR DESCRIPTION
From `yamm` to `mappymatch`.

For titles I spelled it as MapPyMatch. Let me know if you want it spelled differently (like Mappymatch).

To build documentation, run `make html` from the `docs` directory. Then open `docs/_build/html/index.html`.