### PR TITLE
Add workflow for formatting and linting checks

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -1,0 +1,36 @@
+name: Lint and Test
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install black flake8 mypy usort
+    - name: Run black
+      if: always()
+      run: black mappymatch tests --check
+    - name: Run flake8
+      if: always()
+      run: flake8 --ignore E501 mappymatch tests
+    - name: Run mypi
+      if: always()
+      run: mypy mappymatch tests
+    - name: Run usort
+      if: always()
+      run: usort check mappymatch tests
+    - name: Run Tests
+      if: always()
+      run: |
+        echo "Not yet implemented"


### PR DESCRIPTION
This PR contains one new file: `.github/workflows/lint_and_test.yml`. This file will run checks for `black`, `flake8`, `mypy`, and `usort`.

These checks will run any time code is pushed to any branch in the repository.

It also has a placeholder for running tests, but this placehold simply prints `"Not Implemented"`.

Each check is configured such that even if it fails, the other checks will still be run. This is achieved with `if: always()` being configured for each job (a *workflow* in GitHub is comprised on *jobs* that run in sequence).

**Note: the checks introduced in this PR currently fail, but that is expected.**