### PR TITLE
Make originating and destination junction IDs required for Road

### DIFF
--- a/mappymatch/constructs/road.py
+++ b/mappymatch/constructs/road.py
@@ -9,6 +9,7 @@ class Road(NamedTuple):
     road_id: Union[int, str]
 
     geom: LineString
-
+    origin_junction_id: Union[int, str]  # The id of the previous road in the path
+    dest_junction_id: Union[int, str]  # The id of the next road in the path
     # holds any info specific to the road network
     metadata: Optional[dict] = None

--- a/mappymatch/maps/nx/nx_map.py
+++ b/mappymatch/maps/nx/nx_map.py
@@ -67,7 +67,6 @@ class NxMap(MapInterface):
                 d[self._geom_key],
                 origin_junction_id=u,
                 dest_junction_id=v,
-
             )
             road_lookup.append(road)
 
@@ -198,14 +197,12 @@ class NxMap(MapInterface):
             road_id = edge_data[road_key][self._road_id_key]
 
             path.append(
-                Road(road_id, geom, metadata={"u": road_start_node, "v": road_end_node})
                 Road(
                     road_id,
                     geom,
-                    origin_junction_id=road_start_node, 
-                    dest_junction_id=road_end_node},
+                    origin_junction_id=road_start_node,
+                    dest_junction_id=road_end_node,
                 )
-
             )
 
         return path

--- a/mappymatch/matchers/lcss/lcss.py
+++ b/mappymatch/matchers/lcss/lcss.py
@@ -57,7 +57,7 @@ class LCSSMatcher(MatcherInterface):
             if len(a.path) > 1 and len(b.path) > 1:
                 end_road = a.path[-1]
                 start_road = b.path[0]
-                if end_road.metadata["v"] != start_road.metadata["u"]:
+                if end_road.dest_junction_id != start_road.origin_junction_id:
                     o = Coordinate(
                         coordinate_id=None,
                         geom=Point(end_road.geom.coords[-1]),

--- a/mappymatch/utils/plot.py
+++ b/mappymatch/utils/plot.py
@@ -54,11 +54,9 @@ def plot_matches(matches: List[Match], road_map: NxMap):
     def match_to_road(m):
         d = {"road_id": m.road.road_id}
 
-        metadata = m.road.metadata
-        u = metadata["u"]
-        v = metadata["v"]
-
-        edge_data = road_map.g.get_edge_data(u, v)
+        edge_data = road_map.g.get_edge_data(
+            m.road.origin_junction_id, m.road.dest_junction_id
+        )
 
         road_key = list(edge_data.keys())[0]
 
@@ -79,7 +77,6 @@ def plot_matches(matches: List[Match], road_map: NxMap):
         }
 
         return d
-
 
     road_df = pd.DataFrame([match_to_road(m) for m in matches if m.road])
     road_df = road_df.loc[road_df.road_id.shift() != road_df.road_id]

--- a/tests/test_lcss_forward_merge.py
+++ b/tests/test_lcss_forward_merge.py
@@ -101,20 +101,52 @@ class TestLCSSMatcherForwardMerge(TestCase):
         )
 
         road_1 = [
-            Road("first st", LineString(), origin_junction_id=3, dest_junction_id=1)
+            Road(
+                "first st",
+                LineString(),
+                origin_junction_id=3,
+                dest_junction_id=1,
+            )
         ]
         road_2 = [
-            Road("second st", LineString(), origin_junction_id=1, dest_junction_id=2)
+            Road(
+                "second st",
+                LineString(),
+                origin_junction_id=1,
+                dest_junction_id=2,
+            )
         ]
-        road_3 = [Road(234, LineString(), origin_junction_id=2, dest_junction_id=3)]
+        road_3 = [
+            Road(234, LineString(), origin_junction_id=2, dest_junction_id=3)
+        ]
         road_4 = [
-            Road("first st", LineString(), origin_junction_id=3, dest_junction_id=1),
-            Road("second st", LineString(), origin_junction_id=1, dest_junction_id=2),
+            Road(
+                "first st",
+                LineString(),
+                origin_junction_id=3,
+                dest_junction_id=1,
+            ),
+            Road(
+                "second st",
+                LineString(),
+                origin_junction_id=1,
+                dest_junction_id=2,
+            ),
             Road(123, LineString(), origin_junction_id=2, dest_junction_id=4),
         ]
         road_5 = [
-            Road("main st", LineString(), origin_junction_id=4, dest_junction_id=5),
-            Road("second str", LineString(), origin_junction_id=5, dest_junction_id=6),
+            Road(
+                "main st",
+                LineString(),
+                origin_junction_id=4,
+                dest_junction_id=5,
+            ),
+            Road(
+                "second str",
+                LineString(),
+                origin_junction_id=5,
+                dest_junction_id=6,
+            ),
         ]
 
         segment_1 = TrajectorySegment(trace_1, road_1)
@@ -165,18 +197,48 @@ class TestLCSSMatcherForwardMerge(TestCase):
         )
 
         expected_road_1 = [
-            Road("first st", LineString(), origin_junction_id=3, dest_junction_id=1),
-            Road("second st", LineString(), origin_junction_id=1, dest_junction_id=2),
+            Road(
+                "first st",
+                LineString(),
+                origin_junction_id=3,
+                dest_junction_id=1,
+            ),
+            Road(
+                "second st",
+                LineString(),
+                origin_junction_id=1,
+                dest_junction_id=2,
+            ),
         ]
         expected_road_2 = [
             Road(234, LineString(), origin_junction_id=2, dest_junction_id=3),
-            Road("first st", LineString(), origin_junction_id=3, dest_junction_id=1),
-            Road("second st", LineString(), origin_junction_id=1, dest_junction_id=2),
+            Road(
+                "first st",
+                LineString(),
+                origin_junction_id=3,
+                dest_junction_id=1,
+            ),
+            Road(
+                "second st",
+                LineString(),
+                origin_junction_id=1,
+                dest_junction_id=2,
+            ),
             Road(123, LineString(), origin_junction_id=2, dest_junction_id=4),
         ]
         expected_road_3 = [
-            Road("main st", LineString(), origin_junction_id=4, dest_junction_id=5),
-            Road("second str", LineString(), origin_junction_id=5, dest_junction_id=6),
+            Road(
+                "main st",
+                LineString(),
+                origin_junction_id=4,
+                dest_junction_id=5,
+            ),
+            Road(
+                "second str",
+                LineString(),
+                origin_junction_id=5,
+                dest_junction_id=6,
+            ),
         ]
 
         expected_segment_1 = TrajectorySegment(

--- a/tests/test_lcss_forward_merge.py
+++ b/tests/test_lcss_forward_merge.py
@@ -1,11 +1,12 @@
 from unittest import TestCase
+
 import pandas as pd
 from shapely.geometry import LineString
 
-from mappymatch.matchers.lcss.utils import forward_merge
-from mappymatch.constructs.trace import Trace
 from mappymatch.constructs.road import Road
+from mappymatch.constructs.trace import Trace
 from mappymatch.matchers.lcss.constructs import TrajectorySegment
+from mappymatch.matchers.lcss.utils import forward_merge
 
 
 class TestLCSSMatcherForwardMerge(TestCase):
@@ -95,15 +96,22 @@ class TestLCSSMatcherForwardMerge(TestCase):
             )
         )
 
-        road_1 = [Road("first st", LineString())]
-        road_2 = [Road("second st", LineString())]
-        road_3 = [Road(234, LineString())]
-        road_4 = [
-            Road("first st", LineString()),
-            Road("second st", LineString()),
-            Road(123, LineString()),
+        road_1 = [
+            Road("first st", LineString(), origin_junction_id=3, dest_junction_id=1)
         ]
-        road_5 = [Road("main st", LineString()), Road("second str", LineString())]
+        road_2 = [
+            Road("second st", LineString(), origin_junction_id=1, dest_junction_id=2)
+        ]
+        road_3 = [Road(234, LineString(), origin_junction_id=2, dest_junction_id=3)]
+        road_4 = [
+            Road("first st", LineString(), origin_junction_id=3, dest_junction_id=1),
+            Road("second st", LineString(), origin_junction_id=1, dest_junction_id=2),
+            Road(123, LineString(), origin_junction_id=2, dest_junction_id=4),
+        ]
+        road_5 = [
+            Road("main st", LineString(), origin_junction_id=4, dest_junction_id=5),
+            Road("second str", LineString(), origin_junction_id=5, dest_junction_id=6),
+        ]
 
         segment_1 = TrajectorySegment(trace_1, road_1)
         segment_2 = TrajectorySegment(trace_2, road_2)
@@ -148,18 +156,18 @@ class TestLCSSMatcherForwardMerge(TestCase):
         )
 
         expected_road_1 = [
-            Road("first st", LineString()),
-            Road("second st", LineString()),
+            Road("first st", LineString(), origin_junction_id=3, dest_junction_id=1),
+            Road("second st", LineString(), origin_junction_id=1, dest_junction_id=2),
         ]
         expected_road_2 = [
-            Road(234, LineString()),
-            Road("first st", LineString()),
-            Road("second st", LineString()),
-            Road(123, LineString()),
+            Road(234, LineString(), origin_junction_id=2, dest_junction_id=3),
+            Road("first st", LineString(), origin_junction_id=3, dest_junction_id=1),
+            Road("second st", LineString(), origin_junction_id=1, dest_junction_id=2),
+            Road(123, LineString(), origin_junction_id=2, dest_junction_id=4),
         ]
         expected_road_3 = [
-            Road("main st", LineString()),
-            Road("second str", LineString()),
+            Road("main st", LineString(), origin_junction_id=4, dest_junction_id=5),
+            Road("second str", LineString(), origin_junction_id=5, dest_junction_id=6),
         ]
 
         expected_segment_1 = TrajectorySegment(expected_trace_1, expected_road_1)

--- a/tests/test_lcss_reverse_merge.py
+++ b/tests/test_lcss_reverse_merge.py
@@ -1,11 +1,12 @@
 from unittest import TestCase
+
 import pandas as pd
 from shapely.geometry import LineString
 
-from mappymatch.matchers.lcss.utils import reverse_merge
-from mappymatch.constructs.trace import Trace
 from mappymatch.constructs.road import Road
+from mappymatch.constructs.trace import Trace
 from mappymatch.matchers.lcss.constructs import TrajectorySegment
+from mappymatch.matchers.lcss.utils import reverse_merge
 
 
 class TestLCSSMatcherForwardMerge(TestCase):
@@ -95,15 +96,22 @@ class TestLCSSMatcherForwardMerge(TestCase):
             )
         )
 
-        road_1 = [Road("first st", LineString())]
-        road_2 = [Road("second st", LineString())]
-        road_3 = [Road(234, LineString())]
-        road_4 = [
-            Road("first st", LineString()),
-            Road("second st", LineString()),
-            Road(123, LineString()),
+        road_1 = [
+            Road("first st", LineString(), origin_junction_id=0, dest_junction_id=1)
         ]
-        road_5 = [Road("main st", LineString()), Road("second str", LineString())]
+        road_2 = [
+            Road("second st", LineString(), origin_junction_id=1, dest_junction_id=2)
+        ]
+        road_3 = [Road(234, LineString(), origin_junction_id=2, dest_junction_id=3)]
+        road_4 = [
+            Road("first st", LineString(), origin_junction_id=0, dest_junction_id=1),
+            Road("second st", LineString(), origin_junction_id=1, dest_junction_id=2),
+            Road(123, LineString(), origin_junction_id=2, dest_junction_id=5),
+        ]
+        road_5 = [
+            Road("main st", LineString(), origin_junction_id=6, dest_junction_id=7),
+            Road("second str", LineString(), origin_junction_id=7, dest_junction_id=8),
+        ]
 
         segment_1 = TrajectorySegment(trace_1, road_1)
         segment_2 = TrajectorySegment(trace_2, road_2)
@@ -156,20 +164,20 @@ class TestLCSSMatcherForwardMerge(TestCase):
         )
 
         expected_road_1 = [
-            Road("first st", LineString()),
+            Road("first st", LineString(), origin_junction_id=0, dest_junction_id=1)
         ]
         expected_road_2 = [
-            Road("second st", LineString()),
-            Road(234, LineString()),
+            Road("second st", LineString(), origin_junction_id=1, dest_junction_id=2),
+            Road(234, LineString(), origin_junction_id=2, dest_junction_id=3),
         ]
         expected_road_3 = [
-            Road("first st", LineString()),
-            Road("second st", LineString()),
-            Road(123, LineString()),
+            Road("first st", LineString(), origin_junction_id=0, dest_junction_id=1),
+            Road("second st", LineString(), origin_junction_id=1, dest_junction_id=2),
+            Road(123, LineString(), origin_junction_id=2, dest_junction_id=5),
         ]
         expected_road_4 = [
-            Road("main st", LineString()),
-            Road("second str", LineString()),
+            Road("main st", LineString(), origin_junction_id=6, dest_junction_id=7),
+            Road("second str", LineString(), origin_junction_id=7, dest_junction_id=8),
         ]
 
         expected_segment_1 = TrajectorySegment(expected_trace_1, expected_road_1)

--- a/tests/test_lcss_reverse_merge.py
+++ b/tests/test_lcss_reverse_merge.py
@@ -101,22 +101,53 @@ class TestLCSSMatcherForwardMerge(TestCase):
         )
 
         road_1 = [
-            Road("first st", LineString(), origin_junction_id=0, dest_junction_id=1)
+            Road(
+                "first st",
+                LineString(),
+                origin_junction_id=0,
+                dest_junction_id=1,
+            )
         ]
         road_2 = [
-            Road("second st", LineString(), origin_junction_id=1, dest_junction_id=2)
+            Road(
+                "second st",
+                LineString(),
+                origin_junction_id=1,
+                dest_junction_id=2,
+            )
         ]
-        road_3 = [Road(234, LineString(), origin_junction_id=2, dest_junction_id=3)]
+        road_3 = [
+            Road(234, LineString(), origin_junction_id=2, dest_junction_id=3)
+        ]
         road_4 = [
-            Road("first st", LineString(), origin_junction_id=0, dest_junction_id=1),
-            Road("second st", LineString(), origin_junction_id=1, dest_junction_id=2),
+            Road(
+                "first st",
+                LineString(),
+                origin_junction_id=0,
+                dest_junction_id=1,
+            ),
+            Road(
+                "second st",
+                LineString(),
+                origin_junction_id=1,
+                dest_junction_id=2,
+            ),
             Road(123, LineString(), origin_junction_id=2, dest_junction_id=5),
         ]
         road_5 = [
-            Road("main st", LineString(), origin_junction_id=6, dest_junction_id=7),
-            Road("second str", LineString(), origin_junction_id=7, dest_junction_id=8),
+            Road(
+                "main st",
+                LineString(),
+                origin_junction_id=6,
+                dest_junction_id=7,
+            ),
+            Road(
+                "second str",
+                LineString(),
+                origin_junction_id=7,
+                dest_junction_id=8,
+            ),
         ]
-
 
         segment_1 = TrajectorySegment(trace_1, road_1)
         segment_2 = TrajectorySegment(trace_2, road_2)
@@ -169,20 +200,50 @@ class TestLCSSMatcherForwardMerge(TestCase):
         )
 
         expected_road_1 = [
-            Road("first st", LineString(), origin_junction_id=0, dest_junction_id=1)
+            Road(
+                "first st",
+                LineString(),
+                origin_junction_id=0,
+                dest_junction_id=1,
+            )
         ]
         expected_road_2 = [
-            Road("second st", LineString(), origin_junction_id=1, dest_junction_id=2),
+            Road(
+                "second st",
+                LineString(),
+                origin_junction_id=1,
+                dest_junction_id=2,
+            ),
             Road(234, LineString(), origin_junction_id=2, dest_junction_id=3),
         ]
         expected_road_3 = [
-            Road("first st", LineString(), origin_junction_id=0, dest_junction_id=1),
-            Road("second st", LineString(), origin_junction_id=1, dest_junction_id=2),
+            Road(
+                "first st",
+                LineString(),
+                origin_junction_id=0,
+                dest_junction_id=1,
+            ),
+            Road(
+                "second st",
+                LineString(),
+                origin_junction_id=1,
+                dest_junction_id=2,
+            ),
             Road(123, LineString(), origin_junction_id=2, dest_junction_id=5),
         ]
         expected_road_4 = [
-            Road("main st", LineString(), origin_junction_id=6, dest_junction_id=7),
-            Road("second str", LineString(), origin_junction_id=7, dest_junction_id=8),
+            Road(
+                "main st",
+                LineString(),
+                origin_junction_id=6,
+                dest_junction_id=7,
+            ),
+            Road(
+                "second str",
+                LineString(),
+                origin_junction_id=7,
+                dest_junction_id=8,
+            ),
         ]
 
         expected_segment_1 = TrajectorySegment(


### PR DESCRIPTION
Remove the origin and destination junction IDs from the optional metadata attribute of Road and make them required attributes on the object.

This closes issue #60 