### PR TITLE
remove the direct pygeos dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,6 @@ channels:
 dependencies:
   - python=3.8
   - osmnx
-  - pygeos
   - folium
   - requests
 

--- a/mappymatch/maps/nx/nx_map.py
+++ b/mappymatch/maps/nx/nx_map.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import List, Union
 
 import networkx as nx
-from pygeos import STRtree, Geometry
+import rtree as rt
 from shapely.geometry import Point
 
 from mappymatch.constructs.coordinate import Coordinate
@@ -53,23 +53,25 @@ class NxMap(MapInterface):
         self._roads = self._build_rtree()
 
     def _build_rtree(self) -> List[Road]:
-        geoms = []
         road_lookup = []
-        for (
-            u,
-            v,
-            rid,
-            d,
-        ) in self.g.edges(data=True, keys=True):
-            geoms.append(Geometry(d[self._geom_key].wkb))
+
+        idx = rt.index.Index()
+        for i, gtuple in enumerate(self.g.edges(data=True, keys=True)):
+            u, v, k, d = gtuple
+            # rid = (u, v, k)
+            geom = d[self._geom_key]
+            # segment = list(geom.coords)
+            box = geom.bounds
+            idx.insert(i, box)
+
             road = Road(
                 d[self._road_id_key],
-                d[self._geom_key],
+                geom,
                 metadata={"u": u, "v": v},
             )
             road_lookup.append(road)
 
-        self.rtree = STRtree(geoms)
+        self.rtree = idx 
         return road_lookup
 
     @property
@@ -111,9 +113,12 @@ class NxMap(MapInterface):
             raise ValueError(
                 f"crs of origin {coord.crs} must match crs of map {self.crs}"
             )
-        nearest_index = self.rtree.nearest(
-            [Geometry(coord.geom.wkb)]
-        ).tolist()[-1][0]
+        nearest_candidates = list(self.rtree.nearest(coord.geom.bounds, 1))
+
+        if len(nearest_candidates) == 0:
+            raise ValueError(f"No roads found for {coord}")
+        
+        nearest_index = nearest_candidates[0]
 
         road = self.roads[nearest_index]
 

--- a/mappymatch/maps/nx/readers/osm_readers.py
+++ b/mappymatch/maps/nx/readers/osm_readers.py
@@ -10,7 +10,7 @@ from mappymatch.maps.nx.nx_map import NxMap
 from mappymatch.utils.crs import LATLON_CRS, XY_CRS
 from mappymatch.utils.exceptions import MapException
 
-ox.config(log_console=True)
+ox.config(log_console=False)
 log.basicConfig(level=log.INFO)
 
 DEFAULT_MPH = 30

--- a/tests/test_osm.py
+++ b/tests/test_osm.py
@@ -25,7 +25,8 @@ class TestOSMap(TestCase):
         # DEBUG: plot the street it choose using geojson.io
         # import geopandas
         # print(geopandas.GeoSeries(st31.geom).set_crs(XY_CRS).to_crs(LATLON_CRS).to_json())
-        self.assertEqual(st31.road_id, "1321042414-3323569423")
+        possible_ids = ["1321042414-3323569423", "3323569423-1321042414"]
+        self.assertTrue(st31.road_id in possible_ids)
 
         # Make sure the graph contains this road segment
         e23_ave_node1 = osm_map.g.nodes[1321042414]
@@ -56,7 +57,8 @@ class TestOSMap(TestCase):
         # DEBUG: plot the street it choose using geojson.io
         # import geopandas
         # print(geopandas.GeoSeries(st31.geom).set_crs(XY_CRS).to_crs(LATLON_CRS).to_json())
-        self.assertEqual(st31.road_id, "3336866319-3336866337")
+        possible_ids = ["3336866319-3336866337", "3336866337-3336866319"] 
+        self.assertTrue(st31.road_id in possible_ids)
 
         # Make sure the graph contains this road segment
         e23_ave_node1 = osm_map.g.nodes[3336866319]


### PR DESCRIPTION
Closes #71 by removing the pygeos SRTree implementation and using the `rtree` package. When pygeos gets incorporated into shapely we can update our Rtree implementation to use the pygeos one.