### PR TITLE
str and repr for mappymatch objects

### DIFF
--- a/mappymatch/constructs/coordinate.py
+++ b/mappymatch/constructs/coordinate.py
@@ -20,9 +20,15 @@ class Coordinate(NamedTuple):
     geom: Point
     crs: CRS
 
-    def __repr__(self):
+    def _string_rep(self):
         crs_a = self.crs.to_authority() if self.crs else "Null"
         return f"Coordinate(coordinate_id={self.coordinate_id}, x={self.x}, y={self.y}, crs={crs_a})"
+
+    def __repr__(self):
+        return self._string_rep()
+
+    def __str__(self):
+        return self._string_rep()
 
     @classmethod
     def from_lat_lon(cls, lat: float, lon: float) -> Coordinate:

--- a/mappymatch/constructs/trace.py
+++ b/mappymatch/constructs/trace.py
@@ -41,10 +41,10 @@ class Trace:
         return len(self._frame)
 
     def __repr__(self):
-        return(f'_frame: \n{str(self._frame)}')
+        return f"_frame: \n{str(self._frame)}"
 
     def __str__(self):
-        return(f'_frame: \n{str(self._frame)}')
+        return f"_frame: \n{str(self._frame)}"
 
     @property
     def index(self) -> pd.Index:

--- a/mappymatch/constructs/trace.py
+++ b/mappymatch/constructs/trace.py
@@ -40,6 +40,12 @@ class Trace:
     def __len__(self):
         return len(self._frame)
 
+    def __repr__(self):
+        return(f'_frame: \n{str(self._frame)}')
+
+    def __str__(self):
+        return(f'_frame: \n{str(self._frame)}')
+
     @property
     def index(self) -> pd.Index:
         return self._frame.index

--- a/mappymatch/maps/nx/nx_map.py
+++ b/mappymatch/maps/nx/nx_map.py
@@ -54,18 +54,20 @@ class NxMap(MapInterface):
         self._roads = self._build_rtree()
 
     def _strip_verbose_data(self):
-        too_verbose = ('_nodes', '_roads')
-        base_dict = {k: v for k, v in self.__dict__.items() if not k in too_verbose}
+        too_verbose = ("_nodes", "_roads")
+        base_dict = {
+            k: v for k, v in self.__dict__.items() if not k in too_verbose
+        }
         for label in too_verbose:
-            member_len = len(eval(f'self.{label}'))
-            base_dict[label] = f'list of {member_len} elements'
-        return ', '.join(f'{k}: {v}' for k, v in base_dict.items())
+            member_len = len(eval(f"self.{label}"))
+            base_dict[label] = f"list of {member_len} elements"
+        return ", ".join(f"{k}: {v}" for k, v in base_dict.items())
 
     def __str__(self):
-        return 'NXMap(' + self._strip_verbose_data() + ')'
+        return "NXMap(" + self._strip_verbose_data() + ")"
 
     def __repr__(self):
-        return 'NXMap(' + self._strip_verbose_data() + ')'
+        return "NXMap(" + self._strip_verbose_data() + ")"
 
     def _build_rtree(self) -> List[Road]:
         road_lookup = []

--- a/mappymatch/maps/nx/nx_map.py
+++ b/mappymatch/maps/nx/nx_map.py
@@ -53,6 +53,20 @@ class NxMap(MapInterface):
         self._nodes = [nid for nid in self.g.nodes()]
         self._roads = self._build_rtree()
 
+    def _strip_verbose_data(self):
+        too_verbose = ('_nodes', '_roads')
+        base_dict = {k: v for k, v in self.__dict__.items() if not k in too_verbose}
+        for label in too_verbose:
+            member_len = len(eval(f'self.{label}'))
+            base_dict[label] = f'list of {member_len} elements'
+        return ', '.join(f'{k}: {v}' for k, v in base_dict.items())
+
+    def __str__(self):
+        return 'NXMap(' + self._strip_verbose_data() + ')'
+
+    def __repr__(self):
+        return 'NXMap(' + self._strip_verbose_data() + ')'
+
     def _build_rtree(self) -> List[Road]:
         road_lookup = []
 

--- a/mappymatch/maps/nx/nx_map.py
+++ b/mappymatch/maps/nx/nx_map.py
@@ -56,7 +56,7 @@ class NxMap(MapInterface):
     def _strip_verbose_data(self):
         too_verbose = ("_nodes", "_roads")
         base_dict = {
-            k: v for k, v in self.__dict__.items() if not k in too_verbose
+            k: v for k, v in self.__dict__.items() if k not in too_verbose
         }
         for label in too_verbose:
             member_len = len(eval(f"self.{label}"))

--- a/mappymatch/matchers/lcss/lcss.py
+++ b/mappymatch/matchers/lcss/lcss.py
@@ -55,11 +55,10 @@ class LCSSMatcher(MatcherInterface):
         self.distance_threshold = distance_threshold
 
     def _string_rep(self):
-        return (
-            "LCSSMatcher("
-            + ", ".join(f"{k}: {v}" for k, v in self.__dict__.items())
-            + ")"
+        base_dict_str = ", ".join(
+            f"{k}: {v}" for k, v in self.__dict__.items()
         )
+        return "LCSSMatcher(" + base_dict_str + ")"
 
     def __repr__(self):
         return self._string_rep()

--- a/mappymatch/matchers/lcss/lcss.py
+++ b/mappymatch/matchers/lcss/lcss.py
@@ -54,11 +54,18 @@ class LCSSMatcher(MatcherInterface):
         self.random_cuts = random_cuts
         self.distance_threshold = distance_threshold
 
+    def _string_rep(self):
+        return (
+            "LCSSMatcher("
+            + ", ".join(f"{k}: {v}" for k, v in self.__dict__.items())
+            + ")"
+        )
+
     def __repr__(self):
-        return(repr(self.__dict__))
+        return self._string_rep()
 
     def __str__(self):
-        return(str(self.__dict__))
+        return self._string_rep()
 
     def match_trace(self, trace: Trace) -> MatchResult:
         def _join_segment(a: TrajectorySegment, b: TrajectorySegment):

--- a/mappymatch/matchers/lcss/lcss.py
+++ b/mappymatch/matchers/lcss/lcss.py
@@ -54,6 +54,12 @@ class LCSSMatcher(MatcherInterface):
         self.random_cuts = random_cuts
         self.distance_threshold = distance_threshold
 
+    def __repr__(self):
+        return(repr(self.__dict__))
+
+    def __str__(self):
+        return(str(self.__dict__))
+
     def match_trace(self, trace: Trace) -> MatchResult:
         def _join_segment(a: TrajectorySegment, b: TrajectorySegment):
             new_traces = a.trace + b.trace


### PR DESCRIPTION
Addresses issue [#35], adding string representations to objects

Before opening PR for approval, could use feedback on what's useful string representations of objects. Currently on this branch:

```
str(matcher)
"LCSSMatcher({'road_map': NXMap('(g, MultiDiGraph with 1239 nodes and 3417 edges), (crs, epsg:3857), (_dist_weight, kilometers), (_time_weight, travel_time), (_geom_key, geometry), (_road_id_key, road_id), (rtree, rtree.index.Index(bounds=[-11684967.812039806, 4815101.583056703, -11678639.588418882, 4829602.061216707], size=3417)), (_nodes, list of 1239 elements), (_roads, list of 3417 elements)'), 'distance_epsilon': 50.0, 'similarity_cutoff': 0.9, 'cutting_threshold': 10.0, 'random_cuts': 0, 'distance_threshold': 10000})"
```

```
repr(matcher.road_map)

'NXMap(g: MultiDiGraph with 1239 nodes and 3417 edges, crs: epsg:3857, _dist_weight: kilometers, _time_weight: travel_time, _geom_key: geometry, _road_id_key: road_id, rtree: rtree.index.Index(bounds=[-11684967.812039806, 4815101.583056703, -11678639.588418882, 4829602.061216707], size=3417), _nodes: list of 1239 elements, _roads: list of 3417 elements)'
```