### PR TITLE
Bugfix/nearest road

### DIFF
--- a/mappymatch/maps/nx/nx_map.py
+++ b/mappymatch/maps/nx/nx_map.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from typing import List, Union
 
 import networkx as nx
-import rtree as rt
 import numpy as np
+import rtree as rt
 from shapely.geometry import Point
 
 from mappymatch.constructs.coordinate import Coordinate

--- a/mappymatch/matchers/lcss/lcss.py
+++ b/mappymatch/matchers/lcss/lcss.py
@@ -98,15 +98,13 @@ class LCSSMatcher(MatcherInterface):
         dt = self.distance_threshold
         initial_segment = (
             TrajectorySegment(
-                trace=sub_trace, path=new_path(road_map, sub_trace, de)
+                trace=sub_trace, path=new_path(road_map, sub_trace)
             )
             .score_and_match(de, dt)
             .compute_cutting_points(de, ct, rc)
         )
 
-        initial_scheme = split_trajectory_segment(
-            road_map, initial_segment, de
-        )
+        initial_scheme = split_trajectory_segment(road_map, initial_segment)
         scheme = initial_scheme
 
         n = 0
@@ -121,7 +119,7 @@ class LCSSMatcher(MatcherInterface):
                 else:
                     # split and check the score
                     new_split = split_trajectory_segment(
-                        road_map, scored_segment, de
+                        road_map, scored_segment
                     )
                     joined_segment = ft.reduce(
                         _join_segment, new_split

--- a/mappymatch/matchers/lcss/ops.py
+++ b/mappymatch/matchers/lcss/ops.py
@@ -71,16 +71,13 @@ def score(trace: Trace, path: List[Road], distance_epsilon: float) -> float:
 def new_path(
     road_map: MapInterface,
     trace: Trace,
-    distance_epsilon: float,
 ) -> List[Road]:
     """
-    Computes a shortest time and shortest distance path and returns the path
-    that most closely matches the trace.
+    Computes a shortest path and returns the path
 
     Args:
         road_map: the road map to match to
         trace: the trace to match
-        distance_epsilon: the distance epsilon
 
     Returns:
         the path that most closely matches the trace
@@ -91,33 +88,16 @@ def new_path(
     origin = trace.coords[0]
     destination = trace.coords[-1]
 
-    time_path = road_map.shortest_path(
+    new_path = road_map.shortest_path(
         origin, destination, weight=PathWeight.TIME
     )
 
-    dist_path = road_map.shortest_path(
-        origin, destination, weight=PathWeight.DISTANCE
-    )
-
-    if time_path == dist_path:
-        return time_path
-
-    if not time_path and not dist_path:
-        return []
-
-    time_score = score(trace, time_path, distance_epsilon)
-    dist_score = score(trace, dist_path, distance_epsilon)
-
-    if dist_score > time_score:
-        return dist_path
-    else:
-        return time_path
+    return new_path
 
 
 def split_trajectory_segment(
     road_map: MapInterface,
     trajectory_segment: TrajectorySegment,
-    distance_epsilon: float,
 ) -> List[TrajectorySegment]:
     """
     Splits a trajectory segment based on the provided cutting points.
@@ -155,7 +135,7 @@ def split_trajectory_segment(
     # start
     scp = cutting_points[0]
     new_trace = trace[: scp.trace_index]  # type: ignore
-    new_paths.append(new_path(road_map, new_trace, distance_epsilon))
+    new_paths.append(new_path(road_map, new_trace))
     new_traces.append(new_trace)
 
     # mids
@@ -163,13 +143,13 @@ def split_trajectory_segment(
         cp = cutting_points[i]
         ncp = cutting_points[i + 1]
         new_trace = trace[cp.trace_index : ncp.trace_index]  # type: ignore
-        new_paths.append(new_path(road_map, new_trace, distance_epsilon))
+        new_paths.append(new_path(road_map, new_trace))
         new_traces.append(new_trace)
 
     # end
     ecp = cutting_points[-1]
     new_trace = trace[ecp.trace_index :]  # type: ignore
-    new_paths.append(new_path(road_map, new_trace, distance_epsilon))
+    new_paths.append(new_path(road_map, new_trace))
     new_traces.append(new_trace)
 
     if not any(new_paths):

--- a/mappymatch/utils/plot.py
+++ b/mappymatch/utils/plot.py
@@ -177,7 +177,8 @@ def plot_map(tmap: NxMap, m=None):
 
     for t in gdf.itertuples():
         folium.PolyLine(
-            [(lat, lon) for lon, lat in t.geometry.coords], color="red"
+            [(lat, lon) for lon, lat in t.geometry.coords],
+            color="red",
         ).add_to(m)
 
     return m

--- a/mappymatch/utils/plot.py
+++ b/mappymatch/utils/plot.py
@@ -1,16 +1,15 @@
 from typing import List
+
 import folium
-
 import geopandas as gpd
+import matplotlib.pyplot as plt
 import pandas as pd
-
 from shapely.geometry import Point
+
 from mappymatch.constructs.match import Match
 from mappymatch.maps.nx.nx_map import NxMap
-from mappymatch.utils.crs import LATLON_CRS, XY_CRS
 from mappymatch.matchers.matcher_interface import MatchResult
-
-import matplotlib.pyplot as plt
+from mappymatch.utils.crs import LATLON_CRS, XY_CRS
 
 
 def plot_geofence(geofence, m=None):

--- a/tests/test_lcss_same_trajectory_scheme.py
+++ b/tests/test_lcss_same_trajectory_scheme.py
@@ -6,7 +6,6 @@ from shapely.geometry import LineString
 from mappymatch.constructs.road import Road
 from mappymatch.constructs.trace import Trace
 from mappymatch.matchers.lcss.constructs import (
-    TrajectoryScheme,
     TrajectorySegment,
 )
 from mappymatch.matchers.lcss.ops import same_trajectory_scheme


### PR DESCRIPTION
Implements a bugfix in which the `NxMap.nearest_road` was in fact not returning the nearest road. To fix, I've added a buffer around the point when querying the rtree for nearby roads and then explicitly computing the distance between each road and the coordinate and returning the minimum distance.

This also removes the computation of both shortest distance paths and shortest time paths for the LCSS matcher as it was found that they are the same in almost all cases.