### PR TITLE
update match result to include optional path

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include mappymatch/resources *

--- a/examples/line_snap_vs_lcss.py
+++ b/examples/line_snap_vs_lcss.py
@@ -31,11 +31,11 @@ snap_matches = snap_matcher.match_trace(trace)
 
 if PLOT:
     lcss_file = Path("lcss_matches.html")
-    lmap = plot_matches(lcss_matches, road_map=nx_map)
+    lmap = plot_matches(lcss_matches.matches, road_map=nx_map)
     lmap.save(str(lcss_file))
     webbrowser.open(lcss_file.absolute().as_uri())
 
     smap_file = Path("snap_matches.html")
-    smap = plot_matches(snap_matches, road_map=nx_map)
+    smap = plot_matches(snap_matches.matches, road_map=nx_map)
     smap.save(str(smap_file))
     webbrowser.open(smap_file.absolute().as_uri())

--- a/examples/match_one_trace.py
+++ b/examples/match_one_trace.py
@@ -28,7 +28,7 @@ nx_map = NxMap.from_geofence(geofence)
 print("matching .")
 matcher = LCSSMatcher(nx_map)
 
-matches = matcher.match_trace(trace)
+match_result = matcher.match_trace(trace)
 
 if PLOT:
     tmap_file = Path("trace_map.html")
@@ -37,6 +37,6 @@ if PLOT:
     webbrowser.open(tmap_file.absolute().as_uri())
 
     mmap_file = Path("matches_map.html")
-    mmap = plot_matches(matches, road_map=nx_map)
+    mmap = plot_matches(match_result.matches, road_map=nx_map)
     mmap.save(str(mmap_file))
     webbrowser.open(mmap_file.absolute().as_uri())

--- a/mappymatch/matchers/lcss/lcss.py
+++ b/mappymatch/matchers/lcss/lcss.py
@@ -145,7 +145,7 @@ class LCSSMatcher(MatcherInterface):
             matches, stationary_index
         )
 
-        return matches_w_stationary_points
+        return MatchResult(matches_w_stationary_points, joined_segment.path)
 
     def match_trace_batch(
         self,

--- a/mappymatch/matchers/lcss/ops.py
+++ b/mappymatch/matchers/lcss/ops.py
@@ -6,6 +6,7 @@ from typing import Any, List, NamedTuple
 import numpy as np
 
 from mappymatch.constructs.coordinate import Coordinate
+from mappymatch.constructs.match import Match
 from mappymatch.constructs.road import Road
 from mappymatch.constructs.trace import Trace
 from mappymatch.maps.map_interface import MapInterface, PathWeight
@@ -14,7 +15,6 @@ from mappymatch.matchers.lcss.constructs import (
     TrajectorySegment,
 )
 from mappymatch.matchers.lcss.utils import merge
-from mappymatch.matchers.matcher_interface import MatchResult
 
 log = logging.getLogger(__name__)
 
@@ -261,9 +261,9 @@ def drop_stationary_points(
 
 
 def add_matches_for_stationary_points(
-    matches: MatchResult,
+    matches: List[Match],
     stationary_index: List[StationaryIndex],
-) -> MatchResult:
+) -> List[Match]:
     """
     Takes a set of matches and adds duplicate match entries for stationary
 

--- a/mappymatch/matchers/line_snap.py
+++ b/mappymatch/matchers/line_snap.py
@@ -1,13 +1,10 @@
 import logging
 from typing import List
 
+from mappymatch.constructs.match import Match
 from mappymatch.constructs.trace import Trace
 from mappymatch.maps.map_interface import MapInterface
-from mappymatch.matchers.matcher_interface import (
-    Match,
-    MatcherInterface,
-    MatchResult,
-)
+from mappymatch.matchers.matcher_interface import MatcherInterface, MatchResult
 
 log = logging.getLogger(__name__)
 
@@ -35,7 +32,7 @@ class LineSnapMatcher(MatcherInterface):
             match = Match(nearest_road, coord, dist)
             matches.append(match)
 
-        return matches
+        return MatchResult(matches)
 
     def match_trace_batch(self, trace_batch: List[Trace]) -> List[MatchResult]:
         return [self.match_trace(t) for t in trace_batch]

--- a/mappymatch/matchers/match_result.py
+++ b/mappymatch/matchers/match_result.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+from mappymatch.constructs.match import Match
+from mappymatch.constructs.road import Road
+
+
+@dataclass
+class MatchResult:
+    matches: List[Match]
+    path: Optional[List[Road]] = None

--- a/mappymatch/matchers/matcher_interface.py
+++ b/mappymatch/matchers/matcher_interface.py
@@ -1,10 +1,8 @@
 from abc import ABCMeta, abstractmethod
 from typing import List
 
-from mappymatch.constructs.match import Match
 from mappymatch.constructs.trace import Trace
-
-MatchResult = List[Match]
+from mappymatch.matchers.match_result import MatchResult
 
 
 class MatcherInterface(metaclass=ABCMeta):

--- a/mappymatch/matchers/osrm.py
+++ b/mappymatch/matchers/osrm.py
@@ -111,7 +111,7 @@ class OsrmMatcher(MatcherInterface):
 
         result = parse_osrm_json(r.json(), trace)
 
-        return result
+        return MatchResult(result)
 
     def match_trace_batch(self, trace_batch: list[Trace]) -> list[MatchResult]:
         return [self.match_trace(t) for t in trace_batch]

--- a/mappymatch/utils/plot.py
+++ b/mappymatch/utils/plot.py
@@ -190,7 +190,7 @@ def plot_match_distances(matches: MatchResult):
     """
 
     y = [
-        m.distance for m in matches
+        m.distance for m in matches.matches
     ]  # y contains distances to the expected line for all of the matches which will be plotted on the y-axis.
     x = [
         i for i in range(0, len(y))


### PR DESCRIPTION
Closes #159 by updating how we represent a `MatchResult`. Now the match result has the matches _and_ and optional path. 