### PR TITLE
fix valhalla road id assignment; bump version

### DIFF
--- a/mappymatch/constructs/road.py
+++ b/mappymatch/constructs/road.py
@@ -6,9 +6,9 @@ from shapely.geometry import LineString
 
 
 class RoadId(NamedTuple):
-    start: Union[int, str]
-    end: Union[int, str]
-    key: Union[int, str]
+    start: Optional[Union[int, str]]
+    end: Optional[Union[int, str]]
+    key: Optional[Union[int, str]]
 
     def to_string(self) -> str:
         return f"{self.start},{self.end},{self.key}"

--- a/mappymatch/matchers/valhalla.py
+++ b/mappymatch/matchers/valhalla.py
@@ -10,7 +10,7 @@ import requests
 from shapely.geometry import LineString
 
 from mappymatch.constructs.match import Match
-from mappymatch.constructs.road import Road
+from mappymatch.constructs.road import Road, RoadId
 from mappymatch.constructs.trace import Trace
 from mappymatch.matchers.matcher_interface import MatcherInterface, MatchResult
 from mappymatch.utils.crs import LATLON_CRS
@@ -45,6 +45,7 @@ def build_path_from_result(
     path = []
     for edge in edges:
         way_id = edge["way_id"]
+        road_id = RoadId(start=None, end=None, key=way_id)
         start_point_i = edge["begin_shape_index"]
         end_point_i = edge["end_shape_index"]
         start_point = shape[start_point_i]
@@ -59,7 +60,7 @@ def build_path_from_result(
             "length_miles": length,
         }
 
-        road = Road(road_id=way_id, geom=geom, metadata=metadata)
+        road = Road(road_id=road_id, geom=geom, metadata=metadata)
 
         path.append(road)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mappymatch"
-version = "0.4.2"
+version = "0.4.3"
 description = "Package for mapmatching."
 readme = "README.md"
 authors = [{ name = "National Renewable Energy Laboratory" }]

--- a/tests/test_valhalla.py
+++ b/tests/test_valhalla.py
@@ -1,0 +1,21 @@
+from unittest import TestCase
+
+from mappymatch.constructs.trace import Trace
+from mappymatch.matchers.valhalla import ValhallaMatcher
+from tests import get_test_dir
+
+
+class TestTrace(TestCase):
+    def test_valhalla_on_small_trace(self):
+        file = get_test_dir() / "test_assets" / "test_trace.geojson"
+
+        trace = Trace.from_geojson(file, xy=False)
+
+        matcher = ValhallaMatcher()
+
+        result = matcher.match_trace(trace)
+
+        match_df = result.matches_to_dataframe()
+        _ = result.path_to_dataframe()
+
+        self.assertEqual(len(match_df), len(trace))


### PR DESCRIPTION
Closes #183 by fixing how RoadIds get constructed from the valhalla results. Previously we were just assigning the osm way id as the road_id but now we're building a RoadId class and assigning the way id as the road_id.key attribute.