### PR TITLE
add ability to pass osm custom filter

### DIFF
--- a/mappymatch/maps/nx/nx_map.py
+++ b/mappymatch/maps/nx/nx_map.py
@@ -214,6 +214,7 @@ class NxMap(MapInterface):
         geofence: Geofence,
         xy: bool = True,
         network_type: NetworkType = NetworkType.DRIVE,
+        custom_filter: Optional[str] = None,
     ) -> NxMap:
         """
         Read an OSM network graph into a NxMap
@@ -222,6 +223,7 @@ class NxMap(MapInterface):
             geofence: the geofence to clip the graph to
             xy: whether to use xy coordinates or lat/lon
             network_type: the network type to use for the graph
+            custom_filter: a custom filter to pass to osmnx like '["highway"~"motorway|primary"]'
 
         Returns:
             a NxMap
@@ -232,7 +234,10 @@ class NxMap(MapInterface):
             )
 
         nx_graph = nx_graph_from_osmnx(
-            geofence=geofence, network_type=network_type, xy=xy
+            geofence=geofence,
+            network_type=network_type,
+            xy=xy,
+            custom_filter=custom_filter,
         )
 
         return NxMap(nx_graph)

--- a/mappymatch/maps/nx/readers/osm_readers.py
+++ b/mappymatch/maps/nx/readers/osm_readers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging as log
 from enum import Enum
+from typing import Optional
 
 import networkx as nx
 from shapely.geometry import LineString
@@ -31,7 +32,10 @@ class NetworkType(Enum):
 
 
 def nx_graph_from_osmnx(
-    geofence: Geofence, network_type: NetworkType, xy: bool = True
+    geofence: Geofence,
+    network_type: NetworkType,
+    xy: bool = True,
+    custom_filter: Optional[str] = None,
 ) -> nx.MultiDiGraph:
     """
     Build a networkx graph from OSM data
@@ -40,6 +44,7 @@ def nx_graph_from_osmnx(
         geofence: the geofence to clip the graph to
         network_type: the network type to use for the graph
         xy: whether to use xy coordinates or lat/lon
+        custom_filter: a custom filter to pass to osmnx
 
     Returns:
         a networkx graph of the OSM network
@@ -53,9 +58,11 @@ def nx_graph_from_osmnx(
     ox.settings.log_console = False
 
     raw_graph = ox.graph_from_polygon(
-        geofence.geometry, network_type=network_type.value
+        geofence.geometry,
+        network_type=network_type.value,
+        custom_filter=custom_filter,
     )
-    return parse_osmnx_graph(raw_graph, network_type)
+    return parse_osmnx_graph(raw_graph, network_type, xy=xy)
 
 
 def parse_osmnx_graph(


### PR DESCRIPTION
Adds the ability to pass a custom OSM filter to osmnx when building a road network. 

For example you could do something like:

```python
nx_map = NxMap.from_geofence(
    geofence, 
    network_type=NetworkType.DRIVE, 
    custom_filter='["highway"~"motorway|primary"]'
)
```

And only get OSM roads that are motorways or primary roads.

