### PR TITLE
Bugfix/batch logic

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Run black
       run: black . --check
     - name: Run ruff 
-      run: ruff . 
+      run: ruff check . 
     - name: Run mypy
       run: mypy . 
     - name: Run Tests

--- a/mappymatch/matchers/lcss/lcss.py
+++ b/mappymatch/matchers/lcss/lcss.py
@@ -152,7 +152,7 @@ class LCSSMatcher(MatcherInterface):
         trace_batch: List[Trace],
         processes: int = 1,
     ) -> List[MatchResult]:
-        if processes > 1:
+        if processes <= 1:
             results = [self.match_trace(t) for t in trace_batch]
         else:
             with Pool(processes=processes) as p:

--- a/mappymatch/matchers/lcss/lcss.py
+++ b/mappymatch/matchers/lcss/lcss.py
@@ -1,6 +1,5 @@
 import functools as ft
 import logging
-from multiprocessing import Pool
 
 from shapely.geometry import Point
 
@@ -155,7 +154,11 @@ class LCSSMatcher(MatcherInterface):
         if processes <= 1:
             results = [self.match_trace(t) for t in trace_batch]
         else:
-            with Pool(processes=processes) as p:
-                results = p.map(self.match_trace, trace_batch)
+            raise NotImplementedError(
+                "Using `processes>1` is not available due to a known issue with rtree serialization."
+                "See https://github.com/Toblerity/rtree/issues/87 for more information."
+            )
+            # with Pool(processes=processes) as p:
+            #     results = p.map(self.match_trace, trace_batch)
 
         return results

--- a/mappymatch/matchers/match_result.py
+++ b/mappymatch/matchers/match_result.py
@@ -21,7 +21,7 @@ class MatchResult:
             A pandas dataframe
         """
         df = pd.DataFrame([m.to_flat_dict() for m in self.matches])
-        df = df.fillna(np.NAN)
+        df = df.fillna(np.nan)
 
         return df
 
@@ -37,6 +37,6 @@ class MatchResult:
             return pd.DataFrame()
 
         df = pd.DataFrame([r.to_flat_dict() for r in self.path])
-        df = df.fillna(np.NAN)
+        df = df.fillna(np.nan)
 
         return df

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mappymatch"
-version = "0.4.4"
+version = "0.4.5"
 description = "Package for mapmatching."
 readme = "README.md"
 authors = [{ name = "National Renewable Energy Laboratory" }]


### PR DESCRIPTION
Fixes a logic error in the batch processing method described in #187. 

Also raises a `NotImplementedError` for trying to use the batch processing method due to the problem with rtree serialization described in #187.

Bumps version to v0.4.5 to release this bugfix.

@jhoshiko could you take a look when you get a chance?