### PR TITLE
make sure points are created with trace CRS

### DIFF
--- a/mappymatch/matchers/lcss/lcss.py
+++ b/mappymatch/matchers/lcss/lcss.py
@@ -20,7 +20,6 @@ from mappymatch.matchers.matcher_interface import (
     MatchResult,
     Trace,
 )
-from mappymatch.utils.crs import XY_CRS
 
 log = logging.getLogger(__name__)
 
@@ -74,12 +73,12 @@ class LCSSMatcher(MatcherInterface):
                     o = Coordinate(
                         coordinate_id=None,
                         geom=Point(end_road.geom.coords[-1]),
-                        crs=XY_CRS,
+                        crs=new_traces.crs,
                     )
                     d = Coordinate(
                         coordinate_id=None,
                         geom=Point(start_road.geom.coords[0]),
-                        crs=XY_CRS,
+                        crs=new_traces.crs,
                     )
                     path = self.road_map.shortest_path(o, d)
                     new_path = a.path + path + b.path


### PR DESCRIPTION
Before this change, the end/start points of trajectory segments to be joined were always interpreted in `XY_CRS`. If the underlying trace (and map) are not in `XY_CRS`, this re-interpreted the points in `XY_CRS`, leading to `shortest_path` to reject the points due to mismatch between the coordinates `XY_CRS` and the actual CRS of map and trace.